### PR TITLE
Updates per WD-07.

### DIFF
--- a/webauthn/interfaces.idl
+++ b/webauthn/interfaces.idl
@@ -1,87 +1,106 @@
-[SecureContext]
+[SecureContext, Exposed=Window]
 interface PublicKeyCredential : Credential {
-    readonly attribute ArrayBuffer           rawId;
-    readonly attribute AuthenticatorResponse response;
-    readonly attribute AuthenticationExtensions clientExtensionResults;
-};
-
-partial dictionary CredentialRequestOptions {
-    PublicKeyCredentialRequestOptions? publicKey;
+    [SameObject] readonly attribute ArrayBuffer              rawId;
+    [SameObject] readonly attribute AuthenticatorResponse    response;
+    AuthenticationExtensions getClientExtensionResults();
 };
 
 partial dictionary CredentialCreationOptions {
-    MakeCredentialOptions? publicKey;
+    MakePublicKeyCredentialOptions      publicKey;
 };
 
-[SecureContext]
+partial dictionary CredentialRequestOptions {
+    PublicKeyCredentialRequestOptions      publicKey;
+};
+
+partial interface PublicKeyCredential {
+    static Promise < boolean > isUserVerifyingPlatformAuthenticatorAvailable();
+};
+
+[SecureContext, Exposed=Window]
 interface AuthenticatorResponse {
-    readonly attribute ArrayBuffer clientDataJSON;
+    [SameObject] readonly attribute ArrayBuffer      clientDataJSON;
 };
 
-[SecureContext]
+[SecureContext, Exposed=Window]
 interface AuthenticatorAttestationResponse : AuthenticatorResponse {
-    readonly attribute ArrayBuffer attestationObject;
+    [SameObject] readonly attribute ArrayBuffer      attestationObject;
 };
 
-[SecureContext]
+[SecureContext, Exposed=Window]
 interface AuthenticatorAssertionResponse : AuthenticatorResponse {
-    readonly attribute ArrayBuffer      authenticatorData;
-    readonly attribute ArrayBuffer      signature;
+    [SameObject] readonly attribute ArrayBuffer      authenticatorData;
+    [SameObject] readonly attribute ArrayBuffer      signature;
+    [SameObject] readonly attribute ArrayBuffer      userHandle;
 };
 
 dictionary PublicKeyCredentialParameters {
-    required PublicKeyCredentialType  type;
-    required AlgorithmIdentifier   algorithm;
+    required PublicKeyCredentialType      type;
+    required COSEAlgorithmIdentifier      alg;
 };
 
-dictionary PublicKeyCredentialUserEntity : PublicKeyCredentialEntity {
-    DOMString displayName;
-};
+dictionary MakePublicKeyCredentialOptions {
+    required PublicKeyCredentialRpEntity         rp;
+    required PublicKeyCredentialUserEntity       user;
 
-dictionary MakeCredentialOptions {
-    required PublicKeyCredentialEntity rp;
-    required PublicKeyCredentialUserEntity user;
+    required BufferSource                             challenge;
+    required sequence<PublicKeyCredentialParameters>  pubKeyCredParams;
 
-    required BufferSource                         challenge;
-    required sequence<PublicKeyCredentialParameters> parameters;
-
-    unsigned long                        timeout;
-    sequence<PublicKeyCredentialDescriptor> excludeList;
-    AuthenticatorSelectionCriteria       authenticatorSelection;
-    AuthenticationExtensions             extensions;
+    unsigned long                                timeout;
+    sequence<PublicKeyCredentialDescriptor>      excludeCredentials = [];
+    AuthenticatorSelectionCriteria               authenticatorSelection;
+    AttestationConveyancePreference              attestation = "none";
+    AuthenticationExtensions                     extensions;
 };
 
 dictionary PublicKeyCredentialEntity {
-    DOMString id;
-    DOMString name;
-    USVString icon;
+    required DOMString    name;
+    USVString             icon;
+};
+
+dictionary PublicKeyCredentialRpEntity : PublicKeyCredentialEntity {
+    DOMString      id;
+};
+
+dictionary PublicKeyCredentialUserEntity : PublicKeyCredentialEntity {
+    required BufferSource   id;
+    required DOMString      displayName;
 };
 
 dictionary AuthenticatorSelectionCriteria {
-    Attachment    attachment;
-    boolean       requireResidentKey = false;
+    AuthenticatorAttachment      authenticatorAttachment;
+    boolean                      requireResidentKey = false;
+    UserVerificationRequirement  userVerification = "preferred";
 };
 
-enum Attachment {
-    "platform",
-    "cross-platform"
+enum AuthenticatorAttachment {
+    "platform",       // Platform attachment
+    "cross-platform"  // Cross-platform attachment
+};
+
+enum AttestationConveyancePreference {
+    "none",
+    "indirect",
+    "direct"
 };
 
 dictionary PublicKeyCredentialRequestOptions {
     required BufferSource                challenge;
     unsigned long                        timeout;
     USVString                            rpId;
-    sequence<PublicKeyCredentialDescriptor> allowList = [];
+    sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
+    UserVerificationRequirement          userVerification = "preferred";
     AuthenticationExtensions             extensions;
 };
 
-typedef record<DOMString, any> AuthenticationExtensions;
+typedef record<DOMString, any>       AuthenticationExtensions;
 
 dictionary CollectedClientData {
+    required DOMString           type;
     required DOMString           challenge;
     required DOMString           origin;
-    required DOMString           hashAlg;
-    DOMString                    tokenBinding;
+    required DOMString           hashAlgorithm;
+    DOMString                    tokenBindingId;
     AuthenticationExtensions     clientExtensions;
     AuthenticationExtensions     authenticatorExtensions;
 };
@@ -91,17 +110,25 @@ enum PublicKeyCredentialType {
 };
 
 dictionary PublicKeyCredentialDescriptor {
-    required PublicKeyCredentialType type;
-    required BufferSource id;
-    sequence<Transport>   transports;
+    required PublicKeyCredentialType      type;
+    required BufferSource                 id;
+    sequence<AuthenticatorTransport>      transports;
 };
 
-enum Transport {
+enum AuthenticatorTransport {
     "usb",
     "nfc",
     "ble"
 };
 
-typedef sequence<AAGUID> AuthenticatorSelectionList;
+typedef long COSEAlgorithmIdentifier;
 
-typedef BufferSource AAGUID;
+enum UserVerificationRequirement {
+    "required",
+    "preferred",
+    "discouraged"
+};
+
+typedef sequence<AAGUID>      AuthenticatorSelectionList;
+
+typedef BufferSource      AAGUID;


### PR DESCRIPTION
Note in Firefox Nightly these changes cause both getcredential-passing.https.html
and getcredential-passing.https.html to pass, and most of interfaces.https.html
to pass as well.

createcredential-badargs-rp.https.html has some other issues which should be
addressed in a different commit.